### PR TITLE
feat: GA metrics for game/connection events, reconnect resilience, fold-showdown fix

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -16,8 +16,12 @@ jobs:
     - name: Install dependencies
       run: npm ci
     - name: Install Playwright Browsers
+      # fail fast if a browser download stalls instead of hanging until the
+      # job-level timeout kills the whole run
+      timeout-minutes: 15
       run: npx playwright install --with-deps
     - name: Run Playwright tests
+      timeout-minutes: 40
       run: npx playwright test
     - uses: actions/upload-artifact@v4
       if: ${{ !cancelled() }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
-        "@playwright/test": "^1.49.1",
+        "@playwright/test": "^1.61.1",
         "babel-plugin-istanbul": "^7.0.1",
         "gh-pages": "^6.1.1",
         "nyc": "^18.0.0",
@@ -3295,13 +3295,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.49.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.1.tgz",
-      "integrity": "sha512-Ky+BVzPz8pL6PQxHqNRW1k3mIyv933LML7HktS8uik0bUXNCdPhoS/kLihiO1tMf/egaJb4IutXd7UywvXEW+g==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.49.1"
+        "playwright": "1.61.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -14051,13 +14051,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.49.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.1.tgz",
-      "integrity": "sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.49.1"
+        "playwright-core": "1.61.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -14070,9 +14070,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.49.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.1.tgz",
-      "integrity": "sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     ]
   },
   "devDependencies": {
-    "@playwright/test": "^1.49.1",
+    "@playwright/test": "^1.61.1",
     "babel-plugin-istanbul": "^7.0.1",
     "gh-pages": "^6.1.1",
     "nyc": "^18.0.0",

--- a/src/lib/GameRoom.ts
+++ b/src/lib/GameRoom.ts
@@ -1,6 +1,7 @@
 import EventEmitter from "eventemitter3";
 import Deferred from "./Deferred";
 import {EventListener} from "./types";
+import {trackError, trackEvent} from "./analytics";
 
 export type GameRoomStatus =
   | 'NotReady'
@@ -121,6 +122,7 @@ export default class GameRoom<T> {
         this.emitter.emit('event', gameEvent, msg.sender, replay);
       } catch (e) {
         console.error(`[GameRoom] ERROR in event handler for ${(msg.data as any)?.type}:`, e);
+        trackError('game_event_handler', e, {event_type: String((msg.data as any)?.type)});
       }
     });
   }
@@ -165,6 +167,11 @@ export default class GameRoom<T> {
       await new Promise(resolve => setTimeout(resolve, RETRY_DELAY_MS));
     }
     console.warn(`emitEvent (${label}): max retries exceeded, message may be lost.`);
+    trackEvent('msg_send_failed', {
+      kind: label.startsWith('private') ? 'private' : 'public',
+      peers_count: this.mesh.peers.length,
+      has_leader: !!this.mesh.leaderId,
+    });
   }
 
   async emitEvent(e: GameEvent<T>) {

--- a/src/lib/analytics.test.ts
+++ b/src/lib/analytics.test.ts
@@ -1,0 +1,55 @@
+import {trackEvent, trackError} from './analytics';
+
+describe('analytics', () => {
+  afterEach(() => {
+    delete (window as any).gtag;
+  });
+
+  test('trackEvent is a no-op when gtag is not defined', () => {
+    expect(() => trackEvent('some_event', {foo: 'bar'})).not.toThrow();
+  });
+
+  test('trackEvent forwards to gtag when defined', () => {
+    const gtagMock = jest.fn();
+    (window as any).gtag = gtagMock;
+
+    trackEvent('round_start', {round: 1, players_count: 2});
+
+    expect(gtagMock).toHaveBeenCalledWith('event', 'round_start', {
+      round: 1,
+      players_count: 2,
+    });
+  });
+
+  test('trackEvent swallows gtag errors', () => {
+    (window as any).gtag = () => {
+      throw new Error('gtag blew up');
+    };
+    expect(() => trackEvent('some_event')).not.toThrow();
+  });
+
+  test('trackError reports app_error with truncated description', () => {
+    const gtagMock = jest.fn();
+    (window as any).gtag = gtagMock;
+
+    trackError('game_room', new Error('x'.repeat(200)), {round: 3});
+
+    expect(gtagMock).toHaveBeenCalledTimes(1);
+    const [command, name, params] = gtagMock.mock.calls[0];
+    expect(command).toBe('event');
+    expect(name).toBe('app_error');
+    expect(params.error_source).toBe('game_room');
+    expect(params.round).toBe(3);
+    expect(params.description.length).toBeLessThanOrEqual(100);
+    expect(params.description.startsWith('Error: xxx')).toBe(true);
+  });
+
+  test('trackError stringifies non-Error values', () => {
+    const gtagMock = jest.fn();
+    (window as any).gtag = gtagMock;
+
+    trackError('somewhere', 'plain message');
+
+    expect(gtagMock.mock.calls[0][2].description).toBe('plain message');
+  });
+});

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,42 @@
+/**
+ * Thin wrapper around Google Analytics (gtag.js).
+ *
+ * All game and connection telemetry goes through this module so that:
+ * - analytics can never break the game (failures are swallowed),
+ * - environments without gtag (unit tests, local dev) are silent no-ops,
+ * - event names and parameters stay consistent and greppable in one place.
+ *
+ * GA4 limits event parameter values to 100 characters, so free-form
+ * strings (error messages etc.) are truncated before sending.
+ */
+
+export type AnalyticsParams = Record<string, string | number | boolean | undefined>;
+
+const MAX_PARAM_LENGTH = 100;
+
+export function trackEvent(name: string, params?: AnalyticsParams) {
+  try {
+    if (typeof gtag === 'function') {
+      gtag('event', name, params);
+    }
+  } catch (e) {
+    console.debug('Failed to send the analytics event.', e);
+  }
+}
+
+/**
+ * Reports an error condition to GA as an `app_error` event.
+ * @param source a short, stable identifier of where the error occurred
+ * @param error the error object or message
+ * @param params extra parameters to attach
+ */
+export function trackError(source: string, error: unknown, params?: AnalyticsParams) {
+  const description = error instanceof Error
+    ? `${error.name}: ${error.message}`
+    : String(error);
+  trackEvent('app_error', {
+    error_source: source,
+    description: description.slice(0, MAX_PARAM_LENGTH),
+    ...params,
+  });
+}

--- a/src/lib/connectionResilience.test.ts
+++ b/src/lib/connectionResilience.test.ts
@@ -1,0 +1,127 @@
+import EventEmitter from "eventemitter3";
+import enableConnectionResilience, {
+  MAX_RECONNECT_ATTEMPTS,
+  RECONNECT_INTERVAL_MS,
+} from "./connectionResilience";
+
+class FakeMesh {
+  peerId: string | undefined = 'me';
+  peers: string[] = ['me'];
+  private emitter = new EventEmitter();
+
+  on(event: string, listener: (...args: any[]) => void) {
+    this.emitter.on(event, listener);
+  }
+
+  off(event: string, listener: (...args: any[]) => void) {
+    this.emitter.off(event, listener);
+  }
+
+  setPeers(peers: string[]) {
+    this.peers = peers;
+    this.emitter.emit('peersChanged', peers);
+  }
+}
+
+describe('enableConnectionResilience', () => {
+  let gtagMock: jest.Mock;
+  let mesh: FakeMesh;
+  let connectMock: jest.Mock;
+  let teardown: () => void;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    gtagMock = jest.fn();
+    (window as any).gtag = gtagMock;
+    mesh = new FakeMesh();
+    connectMock = jest.fn();
+    teardown = enableConnectionResilience(mesh, {connect: connectMock});
+  });
+
+  afterEach(() => {
+    teardown();
+    jest.useRealTimers();
+    delete (window as any).gtag;
+  });
+
+  const eventsNamed = (name: string) =>
+    gtagMock.mock.calls.filter(([, eventName]) => eventName === name);
+
+  test('reports peer_connected when a new peer joins', () => {
+    mesh.setPeers(['me', 'other']);
+    expect(eventsNamed('peer_connected')).toEqual([
+      ['event', 'peer_connected', {peers_count: 1}],
+    ]);
+
+    // same membership again should not re-report
+    mesh.setPeers(['me', 'other']);
+    expect(eventsNamed('peer_connected').length).toBe(1);
+  });
+
+  test('re-dials a lost peer until it comes back', () => {
+    mesh.setPeers(['me', 'other']);
+    mesh.setPeers(['me']); // 'other' dropped
+
+    expect(eventsNamed('peer_lost').length).toBe(1);
+
+    jest.advanceTimersByTime(RECONNECT_INTERVAL_MS * 3);
+    expect(connectMock).toHaveBeenCalledTimes(3);
+    expect(connectMock).toHaveBeenCalledWith('other');
+
+    // peer comes back
+    mesh.setPeers(['me', 'other']);
+    expect(eventsNamed('peer_reconnected').length).toBe(1);
+
+    // retrying must stop
+    jest.advanceTimersByTime(RECONNECT_INTERVAL_MS * 5);
+    expect(connectMock).toHaveBeenCalledTimes(3);
+  });
+
+  test('gives up after MAX_RECONNECT_ATTEMPTS and reports failure', () => {
+    mesh.setPeers(['me', 'other']);
+    mesh.setPeers(['me']);
+
+    jest.advanceTimersByTime(RECONNECT_INTERVAL_MS * (MAX_RECONNECT_ATTEMPTS + 2));
+
+    expect(connectMock).toHaveBeenCalledTimes(MAX_RECONNECT_ATTEMPTS);
+    expect(eventsNamed('peer_reconnect_failed').length).toBe(1);
+
+    // if the peer later reappears, it is treated as a fresh connection
+    mesh.setPeers(['me', 'other']);
+    expect(eventsNamed('peer_connected').length).toBe(2);
+  });
+
+  test('a reconnected peer that drops again is retried again', () => {
+    mesh.setPeers(['me', 'other']);
+    mesh.setPeers(['me']);
+    mesh.setPeers(['me', 'other']);
+    mesh.setPeers(['me']);
+
+    expect(eventsNamed('peer_lost').length).toBe(2);
+    jest.advanceTimersByTime(RECONNECT_INTERVAL_MS);
+    expect(connectMock).toHaveBeenCalled();
+  });
+
+  test('connect errors do not stop the retry loop', () => {
+    connectMock.mockImplementation(() => {
+      throw new Error('boom');
+    });
+    mesh.setPeers(['me', 'other']);
+    mesh.setPeers(['me']);
+
+    jest.advanceTimersByTime(RECONNECT_INTERVAL_MS * 2);
+    expect(connectMock).toHaveBeenCalledTimes(2);
+  });
+
+  test('teardown stops all retry timers', () => {
+    mesh.setPeers(['me', 'other']);
+    mesh.setPeers(['me']);
+
+    teardown();
+    jest.advanceTimersByTime(RECONNECT_INTERVAL_MS * 5);
+    expect(connectMock).not.toHaveBeenCalled();
+
+    // reinstall so afterEach teardown() is harmless
+    teardown = enableConnectionResilience(mesh, {connect: connectMock});
+  });
+});

--- a/src/lib/connectionResilience.ts
+++ b/src/lib/connectionResilience.ts
@@ -1,0 +1,113 @@
+import {trackEvent} from "./analytics";
+
+/**
+ * Minimal view of DandelionMesh used by this module (also easy to fake in tests).
+ */
+export interface MeshView {
+  readonly peerId: string | undefined;
+  readonly peers: string[];
+  on(event: 'peersChanged', listener: (peers: string[]) => void): void;
+  off(event: 'peersChanged', listener: (peers: string[]) => void): void;
+}
+
+/**
+ * Minimal view of the transport used to re-dial peers.
+ * PeerJSTransport.connect() is idempotent while a connection is open/pending.
+ */
+export interface TransportView {
+  connect(remotePeerId: string): void;
+}
+
+export const RECONNECT_INTERVAL_MS = 5_000;
+export const MAX_RECONNECT_ATTEMPTS = 24; // 24 × 5s = 2 minutes per lost peer
+
+interface RetryState {
+  attempts: number;
+  since: number;
+  timer: ReturnType<typeof setInterval>;
+}
+
+/**
+ * Watches mesh membership and automatically re-dials peers whose WebRTC data
+ * connection dropped (e.g., an unstable TURN relay). dandelion-mesh only dials
+ * bootstrap peers once at startup and never reconnects, so without this any
+ * transient connection loss permanently splits the game.
+ *
+ * Also reports connection telemetry to GA:
+ * - `peer_connected`   — a peer joined (or re-joined) the mesh
+ * - `peer_lost`        — a previously connected peer dropped
+ * - `peer_reconnected` — a lost peer was recovered by re-dialing
+ * - `peer_reconnect_failed` — gave up re-dialing after MAX_RECONNECT_ATTEMPTS
+ *
+ * @returns a teardown function that removes the listener and all retry timers.
+ */
+export default function enableConnectionResilience(mesh: MeshView, transport: TransportView): () => void {
+  const knownPeers = new Set<string>();
+  const retries = new Map<string, RetryState>();
+
+  const stopRetrying = (peerId: string) => {
+    const state = retries.get(peerId);
+    if (state) {
+      clearInterval(state.timer);
+      retries.delete(peerId);
+    }
+    return state;
+  };
+
+  const startRetrying = (peerId: string) => {
+    const since = Date.now();
+    const state: RetryState = {
+      attempts: 0,
+      since,
+      timer: setInterval(() => {
+        state.attempts++;
+        if (state.attempts > MAX_RECONNECT_ATTEMPTS) {
+          stopRetrying(peerId);
+          knownPeers.delete(peerId);
+          trackEvent('peer_reconnect_failed', {
+            duration_seconds: Math.round((Date.now() - since) / 1000),
+          });
+          return;
+        }
+        try {
+          transport.connect(peerId);
+        } catch (e) {
+          console.debug(`Reconnect attempt to ${peerId} failed.`, e);
+        }
+      }, RECONNECT_INTERVAL_MS),
+    };
+    retries.set(peerId, state);
+  };
+
+  const peersChangedListener = (peers: string[]) => {
+    const others = new Set(peers.filter(p => p !== mesh.peerId));
+
+    for (const peerId of Array.from(others)) {
+      const retryState = stopRetrying(peerId);
+      if (retryState) {
+        trackEvent('peer_reconnected', {
+          duration_seconds: Math.round((Date.now() - retryState.since) / 1000),
+        });
+      } else if (!knownPeers.has(peerId)) {
+        trackEvent('peer_connected', {peers_count: others.size});
+      }
+      knownPeers.add(peerId);
+    }
+
+    for (const peerId of Array.from(knownPeers)) {
+      if (!others.has(peerId) && !retries.has(peerId)) {
+        trackEvent('peer_lost', {peers_count: others.size});
+        startRetrying(peerId);
+      }
+    }
+  };
+
+  mesh.on('peersChanged', peersChangedListener);
+
+  return () => {
+    mesh.off('peersChanged', peersChangedListener);
+    for (const peerId of Array.from(retries.keys())) {
+      stopRetrying(peerId);
+    }
+  };
+}

--- a/src/lib/instrumentation.test.ts
+++ b/src/lib/instrumentation.test.ts
@@ -1,0 +1,141 @@
+import EventEmitter from "eventemitter3";
+import instrumentGame, {STALL_TIMEOUT_MS} from "./instrumentation";
+
+describe('instrumentGame', () => {
+  let gtagMock: jest.Mock;
+  let gameRoomEmitter: EventEmitter;
+  let texasHoldemEmitter: EventEmitter;
+  let teardown: () => void;
+
+  const gameRoom = () => ({
+    listener: gameRoomEmitter,
+    peerId: 'me',
+  });
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    gtagMock = jest.fn();
+    (window as any).gtag = gtagMock;
+    gameRoomEmitter = new EventEmitter();
+    texasHoldemEmitter = new EventEmitter();
+    teardown = instrumentGame({listener: texasHoldemEmitter}, gameRoom());
+  });
+
+  afterEach(() => {
+    teardown();
+    jest.useRealTimers();
+    delete (window as any).gtag;
+  });
+
+  const eventsNamed = (name: string) =>
+    gtagMock.mock.calls.filter(([, eventName]) => eventName === name);
+
+  test('reports round_start for live newRound events', () => {
+    gameRoomEmitter.emit('event', {
+      data: {type: 'newRound', round: 1, players: ['me', 'other']},
+    }, 'me', false);
+
+    expect(eventsNamed('round_start')).toEqual([
+      ['event', 'round_start', {round: 1, players_count: 2}],
+    ]);
+  });
+
+  test('does not report replayed events', () => {
+    gameRoomEmitter.emit('event', {
+      data: {type: 'newRound', round: 1, players: ['me', 'other']},
+    }, 'me', true);
+    gameRoomEmitter.emit('event', {
+      data: {type: 'action/bet', round: 1, amount: 2},
+    }, 'me', true);
+
+    expect(gtagMock).not.toHaveBeenCalled();
+  });
+
+  test('reports only own player actions', () => {
+    gameRoomEmitter.emit('event', {
+      data: {type: 'action/bet', round: 1, amount: 2},
+    }, 'me', false);
+    gameRoomEmitter.emit('event', {
+      data: {type: 'action/fold', round: 1},
+    }, 'other', false);
+
+    expect(eventsNamed('player_action')).toEqual([
+      ['event', 'player_action', {action_type: 'bet', round: 1}],
+    ]);
+  });
+
+  test('reports round_end with duration for live rounds only', () => {
+    gameRoomEmitter.emit('event', {
+      data: {type: 'newRound', round: 1, players: ['me', 'other']},
+    }, 'me', false);
+
+    texasHoldemEmitter.emit('winner', {round: 1, how: 'Showdown'});
+
+    const roundEndEvents = eventsNamed('round_end');
+    expect(roundEndEvents.length).toBe(1);
+    expect(roundEndEvents[0][2]).toMatchObject({round: 1, how: 'Showdown'});
+    expect(typeof roundEndEvents[0][2].duration_seconds).toBe('number');
+
+    // a winner for a round that was never started live (e.g., replayed) is ignored
+    texasHoldemEmitter.emit('winner', {round: 0, how: 'LastOneWins'});
+    expect(eventsNamed('round_end').length).toBe(1);
+  });
+
+  test('reports game_stalled when a turn is pending for too long', () => {
+    texasHoldemEmitter.emit('whoseTurn', 1, 'me', {callAmount: 2});
+
+    jest.advanceTimersByTime(STALL_TIMEOUT_MS + 1);
+
+    expect(eventsNamed('game_stalled')).toEqual([
+      ['event', 'game_stalled', {
+        round: 1,
+        waiting_for_self: true,
+        seconds_waiting: STALL_TIMEOUT_MS / 1000,
+      }],
+    ]);
+  });
+
+  test('does not report game_stalled if the turn advances in time', () => {
+    texasHoldemEmitter.emit('whoseTurn', 1, 'other', {callAmount: 2});
+    jest.advanceTimersByTime(STALL_TIMEOUT_MS / 2);
+
+    // turn advances: timer must reset
+    texasHoldemEmitter.emit('whoseTurn', 1, 'me', {callAmount: 0});
+    jest.advanceTimersByTime(STALL_TIMEOUT_MS / 2 + 1);
+    expect(eventsNamed('game_stalled').length).toBe(0);
+
+    // round finishes: timer must be cleared
+    texasHoldemEmitter.emit('winner', {round: 1, how: 'LastOneWins'});
+    jest.advanceTimersByTime(STALL_TIMEOUT_MS * 2);
+    expect(eventsNamed('game_stalled').length).toBe(0);
+  });
+
+  test('clears the stall timer when whoseTurn becomes null', () => {
+    texasHoldemEmitter.emit('whoseTurn', 1, 'me', {callAmount: 2});
+    texasHoldemEmitter.emit('whoseTurn', 1, null);
+
+    jest.advanceTimersByTime(STALL_TIMEOUT_MS * 2);
+    expect(eventsNamed('game_stalled').length).toBe(0);
+  });
+
+  test('reports game room status changes', () => {
+    gameRoomEmitter.emit('status', 'PeerServerConnected');
+    expect(eventsNamed('game_room_status')).toEqual([
+      ['event', 'game_room_status', {status: 'PeerServerConnected'}],
+    ]);
+  });
+
+  test('teardown removes listeners and timers', () => {
+    teardown();
+    gameRoomEmitter.emit('event', {
+      data: {type: 'newRound', round: 1, players: ['me', 'other']},
+    }, 'me', false);
+    texasHoldemEmitter.emit('whoseTurn', 1, 'me', {callAmount: 2});
+    jest.advanceTimersByTime(STALL_TIMEOUT_MS * 2);
+
+    expect(gtagMock).not.toHaveBeenCalled();
+
+    // reinstall so afterEach teardown() is harmless
+    teardown = instrumentGame({listener: texasHoldemEmitter}, gameRoom());
+  });
+});

--- a/src/lib/instrumentation.ts
+++ b/src/lib/instrumentation.ts
@@ -1,0 +1,128 @@
+import {trackEvent} from "./analytics";
+
+/**
+ * Minimal structural interfaces so this module can be wired to the real
+ * TexasHoldemGameRoom / GameRoom instances in setup.ts and to lightweight
+ * fakes in unit tests.
+ */
+interface TexasHoldemListenerLike {
+  on(event: string, listener: (...args: any[]) => void): unknown;
+  off(event: string, listener: (...args: any[]) => void): unknown;
+}
+
+interface GameRoomLike {
+  listener: TexasHoldemListenerLike;
+  peerId?: string;
+}
+
+interface TexasHoldemLike {
+  listener: TexasHoldemListenerLike;
+}
+
+/** How long a pending turn may sit without any action before it is reported as a stall. */
+export const STALL_TIMEOUT_MS = 2 * 60 * 1000;
+
+/**
+ * Wires Google Analytics events to the game rooms so GA can answer:
+ * - how far do sessions get (connected → round started → round finished)?
+ * - how many rounds does a session play, and how long does each take?
+ * - do games silently stall mid-round (the "session ends early" symptom)?
+ *
+ * Replay-awareness: after a page refresh the Raft log re-fires every past
+ * event. Raw table events are observed on the GameRoom (which carries the
+ * replay flag) and replayed events are not re-counted. Round-end events are
+ * only reported for rounds whose start was seen live in this page's lifetime.
+ *
+ * @returns a teardown function that removes all listeners and timers.
+ */
+export default function instrumentGame(texasHoldem: TexasHoldemLike, gameRoom: GameRoomLike): () => void {
+  // rounds started live (not via replay) in this page's lifetime → start timestamp
+  const liveRoundStartTimes = new Map<number, number>();
+
+  let stallTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const clearStallTimer = () => {
+    if (stallTimer !== null) {
+      clearTimeout(stallTimer);
+      stallTimer = null;
+    }
+  };
+
+  const armStallTimer = (round: number, whoseTurn: string) => {
+    clearStallTimer();
+    stallTimer = setTimeout(() => {
+      trackEvent('game_stalled', {
+        round,
+        waiting_for_self: whoseTurn === gameRoom.peerId,
+        seconds_waiting: Math.round(STALL_TIMEOUT_MS / 1000),
+      });
+    }, STALL_TIMEOUT_MS);
+  };
+
+  const tableEventListener = (e: {data?: {type?: string, round?: number, players?: string[]}}, who: string, replay?: boolean) => {
+    if (replay || !e.data) {
+      return;
+    }
+    switch (e.data.type) {
+      case 'newRound':
+        if (typeof e.data.round === 'number') {
+          liveRoundStartTimes.set(e.data.round, Date.now());
+          trackEvent('round_start', {
+            round: e.data.round,
+            players_count: e.data.players?.length,
+          });
+        }
+        break;
+      case 'action/bet':
+      case 'action/fold':
+        // only count the local player's own actions, otherwise every client
+        // would report every player's action and inflate the counts
+        if (who === gameRoom.peerId) {
+          trackEvent('player_action', {
+            action_type: e.data.type === 'action/bet' ? 'bet' : 'fold',
+            round: e.data.round,
+          });
+        }
+        break;
+    }
+  };
+
+  const statusListener = (status: string) => {
+    trackEvent('game_room_status', {status});
+  };
+
+  const whoseTurnListener = (round: number, whose: string | null) => {
+    if (whose) {
+      armStallTimer(round, whose);
+    } else {
+      clearStallTimer();
+    }
+  };
+
+  const winnerListener = (result: {round: number, how: string}) => {
+    clearStallTimer();
+    const startTime = liveRoundStartTimes.get(result.round);
+    if (startTime === undefined) {
+      return; // round was replayed (page refresh), already counted before
+    }
+    liveRoundStartTimes.delete(result.round);
+    trackEvent('round_end', {
+      round: result.round,
+      how: result.how,
+      duration_seconds: Math.round((Date.now() - startTime) / 1000),
+    });
+  };
+
+  gameRoom.listener.on('event', tableEventListener);
+  gameRoom.listener.on('status', statusListener);
+  texasHoldem.listener.on('whoseTurn', whoseTurnListener);
+  texasHoldem.listener.on('winner', winnerListener);
+
+  return () => {
+    clearStallTimer();
+    gameRoom.listener.off('event', tableEventListener);
+    gameRoom.listener.off('status', statusListener);
+    texasHoldem.listener.off('whoseTurn', whoseTurnListener);
+    texasHoldem.listener.off('winner', winnerListener);
+  };
+}

--- a/src/lib/setup.ts
+++ b/src/lib/setup.ts
@@ -2,6 +2,7 @@ import MentalPokerGameRoom, {MentalPokerEvent} from "./MentalPokerGameRoom";
 import GameRoom from "./GameRoom";
 import {TexasHoldemGameRoom, TexasHoldemTableEvent} from "./texas-holdem/TexasHoldemGameRoom";
 import ChatRoom, {ChatRoomEvent} from "./ChatRoom";
+import Peer from "peerjs";
 import {
   CryptoKeyBundle,
   DandelionMesh,
@@ -9,6 +10,9 @@ import {
   PeerJSTransport,
   SessionStorageRaftLog,
 } from "dandelion-mesh";
+import {trackError, trackEvent} from "./analytics";
+import instrumentGame from "./instrumentation";
+import enableConnectionResilience from "./connectionResilience";
 
 type AllEvents = MentalPokerEvent | ChatRoomEvent | TexasHoldemTableEvent;
 
@@ -16,6 +20,10 @@ const MODULUS_LENGTH = 2048;
 const SESSION_KEY_BUNDLE = 'mental-holdem:keyBundle';
 const SESSION_PEER_ID = 'mental-holdem:peerId';
 const SESSION_BOOTSTRAP_PEERS = 'mental-holdem:bootstrapPeers';
+
+const INITIAL_CONNECT_TIMEOUT_MS = 30_000;
+const SIGNALING_RECONNECT_DELAY_MS = 3_000;
+const MAX_SIGNALING_RECONNECT_ATTEMPTS = 10;
 
 /**
  * Derive a short, deterministic peer ID from an RSA public key JWK.
@@ -89,12 +97,18 @@ async function getOrCreateSessionKeyBundle(): Promise<{
  * tests, e2e tests) we return `undefined` so PeerJS falls back to its built-in
  * ICE servers. Note that, because there is no backend, the key is necessarily
  * plaintext in the shipped bundle.
+ *
+ * The outcome is reported to GA as `ice_config_loaded`: sessions with
+ * `turn_enabled: false` only have STUN available, so peers behind symmetric
+ * NATs will not be able to establish a WebRTC connection at all.
  */
 async function fetchMeteredIceServers(): Promise<RTCIceServer[] | undefined> {
   const apiKey = process.env.REACT_APP_METERED_API_KEY;
   if (!apiKey) {
+    trackEvent('ice_config_loaded', { turn_enabled: false, reason: 'no_api_key' });
     return undefined;
   }
+  const startedAt = Date.now();
   try {
     const response = await fetch(
       `https://predatorray.metered.live/api/v1/turn/credentials?apiKey=${apiKey}`,
@@ -102,14 +116,133 @@ async function fetchMeteredIceServers(): Promise<RTCIceServer[] | undefined> {
     if (!response.ok) {
       throw new Error(`metered.ca responded with ${response.status}`);
     }
-    return await response.json();
+    const iceServers = await response.json();
+    trackEvent('ice_config_loaded', { turn_enabled: true, duration_ms: Date.now() - startedAt });
+    return iceServers;
   } catch (err) {
     console.error('Failed to fetch ICE servers from metered.ca; falling back to PeerJS defaults.', err);
+    trackError('ice_config', err);
+    trackEvent('ice_config_loaded', { turn_enabled: false, reason: 'fetch_failed' });
     return undefined;
   }
 }
 
+/**
+ * Report uncaught errors and unhandled promise rejections to GA, so crashes
+ * that silently kill a session become visible in the dashboards.
+ */
+function installGlobalErrorTracking() {
+  window.addEventListener('error', (e) => {
+    trackEvent('js_error', { message: String(e.message).slice(0, 100) });
+  });
+  window.addEventListener('unhandledrejection', (e) => {
+    const reason = (e as PromiseRejectionEvent).reason;
+    const message = reason instanceof Error ? `${reason.name}: ${reason.message}` : String(reason);
+    trackEvent('js_error', { message: message.slice(0, 100), unhandled_rejection: true });
+  });
+}
+
+/**
+ * PeerJS does not reconnect to its signaling server on its own. While the
+ * signaling connection is down no new WebRTC connection can be negotiated:
+ * nobody can join the room and lost peers cannot be re-dialed. Reconnect
+ * with a small delay and report both the loss and the recovery to GA.
+ */
+function installSignalingReconnect(peer: Peer) {
+  let attempts = 0;
+  peer.on('disconnected', () => {
+    trackEvent('signaling_lost', { reconnect_attempts_before: attempts });
+    if (attempts >= MAX_SIGNALING_RECONNECT_ATTEMPTS) {
+      return;
+    }
+    attempts++;
+    setTimeout(() => {
+      if (!peer.destroyed && peer.disconnected) {
+        try {
+          peer.reconnect();
+        } catch (e) {
+          trackError('signaling_reconnect', e);
+        }
+      }
+    }, SIGNALING_RECONNECT_DELAY_MS);
+  });
+  peer.on('open', () => {
+    if (attempts > 0) {
+      trackEvent('signaling_restored', { attempts });
+      attempts = 0;
+    }
+  });
+}
+
+/**
+ * A minimal Peer facade handed to PeerJSTransport that swallows repeated
+ * 'open' events.
+ *
+ * DandelionMesh re-initializes its internal Raft node every time the transport
+ * emits 'open'. After a signaling reconnect (see installSignalingReconnect)
+ * PeerJS emits 'open' again, which would leave a second, orphaned Raft node
+ * running — its election timers would keep escalating terms and destabilize
+ * the whole cluster. The mesh must therefore only ever observe the first
+ * 'open'; our own listeners are attached to the real Peer instance instead.
+ */
+function meshFacingPeer(peer: Peer): Peer {
+  let opened = false;
+  const facade = {
+    on(event: string, listener: (...args: unknown[]) => void) {
+      if (event === 'open') {
+        peer.on('open', (id: string) => {
+          if (!opened) {
+            opened = true;
+            listener(id);
+          }
+        });
+        return;
+      }
+      peer.on(event as any, listener as any);
+    },
+    connect: peer.connect.bind(peer),
+    destroy: peer.destroy.bind(peer),
+  };
+  return facade as unknown as Peer;
+}
+
+/**
+ * Report whether this client managed to reach any of its bootstrap peers
+ * (i.e., the game room it was invited to, or the peers known before a
+ * refresh) within a timeout. This is the primary success/failure signal
+ * for WebRTC (TURN) connection establishment in GA.
+ */
+function watchInitialConnection(mesh: DandelionMesh<AllEvents>, bootstrapPeers: string[], role: string) {
+  const startedAt = Date.now();
+  const cleanup = () => {
+    clearTimeout(timer);
+    mesh.off('peersChanged', listener);
+  };
+  const listener = (peers: string[]) => {
+    if (bootstrapPeers.some(bp => peers.includes(bp))) {
+      cleanup();
+      trackEvent('bootstrap_connect_result', {
+        success: true,
+        role,
+        duration_ms: Date.now() - startedAt,
+      });
+    }
+  };
+  const timer = setTimeout(() => {
+    cleanup();
+    trackEvent('bootstrap_connect_result', {
+      success: false,
+      role,
+      timeout_ms: INITIAL_CONNECT_TIMEOUT_MS,
+    });
+  }, INITIAL_CONNECT_TIMEOUT_MS);
+  mesh.on('peersChanged', listener);
+}
+
 async function initSetup() {
+  const setupStartedAt = Date.now();
+  installGlobalErrorTracking();
+
   const { bundle, peerId } = await getOrCreateSessionKeyBundle();
 
   const iceServers = await fetchMeteredIceServers();
@@ -122,16 +255,40 @@ async function initSetup() {
     ? [bootstrapPeerFromUrl]
     : storedBootstrapPeers;
 
-  const transport = new PeerJSTransport({
-    peerId,
-    ...(iceServers ? { peerOptions: { config: { iceServers } } } : {}),
-  });
+  const role = bootstrapPeerFromUrl ? 'guest' : (storedBootstrapPeers.length > 0 ? 'rejoin' : 'host');
+
+  const peer = new Peer(peerId, iceServers ? { config: { iceServers } } : undefined);
+  installSignalingReconnect(peer);
+
+  const transport = new PeerJSTransport(meshFacingPeer(peer));
   const mesh = new DandelionMesh<AllEvents>(transport, {
     bootstrapPeers,
     modulusLength: MODULUS_LENGTH,
     cryptoKeyBundle: bundle,
     raftLog: new SessionStorageRaftLog('mental-holdem'),
   });
+
+  mesh.on('ready', () => {
+    trackEvent('peer_open', { role, duration_ms: Date.now() - setupStartedAt });
+  });
+  mesh.on('error', (err) => {
+    // PeerJS errors carry a machine-readable `type` (e.g. 'peer-unavailable',
+    // 'network', 'server-error'); connection-level errors may not.
+    trackEvent('connection_error', {
+      error_type: String((err as { type?: string })?.type ?? 'unknown'),
+      message: String((err as Error)?.message ?? err).slice(0, 100),
+    });
+  });
+  mesh.on('leaderChanged', (leaderId) => {
+    trackEvent('raft_leader_changed', { has_leader: !!leaderId });
+  });
+
+  if (bootstrapPeers.length > 0) {
+    watchInitialConnection(mesh, bootstrapPeers, role);
+  }
+
+  // Re-dial peers whose WebRTC connection dropped (e.g., unstable TURN relay).
+  const stopConnectionResilience = enableConnectionResilience(mesh, transport);
 
   const gameRoom = new GameRoom<AllEvents>(mesh, {
     hostId: bootstrapPeerFromUrl,
@@ -152,7 +309,11 @@ async function initSetup() {
 
   const chat = new ChatRoom(gameRoom);
 
+  const stopGameInstrumentation = instrumentGame(texasHoldem, gameRoom);
+
   window.addEventListener('beforeunload', () => {
+    stopGameInstrumentation();
+    stopConnectionResilience();
     texasHoldem.close();
     chat.close();
     gameRoom.close();

--- a/src/lib/texas-holdem/TexasHoldemGameRoom.test.ts
+++ b/src/lib/texas-holdem/TexasHoldemGameRoom.test.ts
@@ -598,24 +598,41 @@ describe('TexasHoldemGameRoom with multiple players', () => {
     ]);
   });
 
+  // Helper: emit hole cards for all players so hole events resolve.
+  // Player i gets ranks (i*2+2, i*2+3), e.g., player 0: 2c 3d, player 1: 4c 5d.
+  const emitHoleCards = (
+    round: number,
+    players: string[],
+    mentalPokerGameRooms: MockMentalPokerGameRoom[],
+  ) => {
+    for (let i = 0; i < players.length; i++) {
+      const card1 = { suit: 'Club', rank: String(i * 2 + 2) };
+      const card2 = { suit: 'Diamond', rank: String(i * 2 + 3) };
+      for (let mpgr of mentalPokerGameRooms) {
+        mpgr.listener.emit('card', round, i * 2 + 5, card1 as any);
+        mpgr.listener.emit('card', round, i * 2 + 6, card2 as any);
+      }
+    }
+  };
+
   // Helper: start a round and return round number. Sets up funds at 100 each.
   const startRound = async (
     hostTexasHoldemGameRoom: TexasHoldemGameRoom,
     hostMentalPokerGameRoom: MockMentalPokerGameRoom,
     guestMentalPokerGameRoom?: MockMentalPokerGameRoom,
     guestMentalPokerGameRooms?: MockMentalPokerGameRoom[],
+    options?: {
+      // when true, hole cards are not resolved up-front; tests that need the
+      // showdown to happen after betting (as in real play, where cards are
+      // only decrypted once betting completes) emit them via emitHoleCards
+      skipHoleCards?: boolean,
+    },
   ) => {
     const playersPromise = listenOnce(hostTexasHoldemGameRoom, 'players');
     await hostTexasHoldemGameRoom.startNewRound({ initialFundAmount: 100 });
     const [round, players] = await playersPromise;
-    // Emit hole cards for all players so hole events resolve
-    for (let i = 0; i < players.length; i++) {
-      const card1 = { suit: 'Club', rank: String(i * 2 + 2) };
-      const card2 = { suit: 'Diamond', rank: String(i * 2 + 3) };
-      for (let mpgr of [hostMentalPokerGameRoom, ...(guestMentalPokerGameRooms ?? (guestMentalPokerGameRoom ? [guestMentalPokerGameRoom] : []))]) {
-        mpgr.listener.emit('card', round, i * 2 + 5, card1 as any);
-        mpgr.listener.emit('card', round, i * 2 + 6, card2 as any);
-      }
+    if (!options?.skipHoleCards) {
+      emitHoleCards(round, players, [hostMentalPokerGameRoom, ...(guestMentalPokerGameRooms ?? (guestMentalPokerGameRoom ? [guestMentalPokerGameRoom] : []))]);
     }
     // Flush microtasks so handleNewRoundEvent completes (dealCard awaits + blind bets)
     await new Promise(r => setTimeout(r, 0));
@@ -733,7 +750,11 @@ describe('TexasHoldemGameRoom with multiple players', () => {
     const boardSubscriber = subscribeEvents(hostTexasHoldemGameRoom, 'board');
     const winnerSubscriber = subscribeEvents(hostTexasHoldemGameRoom, 'winner');
 
-    const { round } = await startRound(hostTexasHoldemGameRoom, hostMentalPokerGameRoom, guestMentalPokerGameRoom);
+    // hole cards are revealed only after river betting completes, as in real
+    // play; otherwise the showdown result would be computed too early
+    const { round, players } = await startRound(
+      hostTexasHoldemGameRoom, hostMentalPokerGameRoom, guestMentalPokerGameRoom, undefined,
+      { skipHoleCards: true });
 
     // Pre-flop: host calls, guest checks
     await hostTexasHoldemGameRoom.bet(round, 1);
@@ -790,8 +811,8 @@ describe('TexasHoldemGameRoom with multiple players', () => {
       ])
     );
 
-    // Emit all board cards for showdown winner resolution
-    // (board cards already emitted above)
+    // Emit the hole cards revealed at showdown so the winner can be resolved
+    emitHoleCards(round, players, allRooms);
     await new Promise(r => setTimeout(r, 50));
 
     const winnerEvents = winnerSubscriber.pop();
@@ -799,6 +820,69 @@ describe('TexasHoldemGameRoom with multiple players', () => {
     expect(winnerEvents[0][0].how).toBe('Showdown');
     expect(winnerEvents[0][0].round).toBe(round);
   });
+
+  testHostAndGuest('folded player is excluded from showdown even with the best hand', async (
+    {
+      hostMentalPokerGameRoom,
+      hostTexasHoldemGameRoom,
+      guestMentalPokerGameRooms,
+      guestTexasHoldemGameRooms,
+    }
+  ) => {
+    const allRooms = [hostMentalPokerGameRoom, ...guestMentalPokerGameRooms];
+    const winnerSubscriber = subscribeEvents(hostTexasHoldemGameRoom, 'winner');
+    const fundSubscriber = subscribeEvents(hostTexasHoldemGameRoom, 'fund');
+
+    // players: host (SB), guest0 (BB), guest1
+    // startRound deals fixed holes: host = 2c 3d, guest0 = 4c 5d, guest1 = 6c 7d
+    const { round } = await startRound(
+      hostTexasHoldemGameRoom, hostMentalPokerGameRoom, undefined, guestMentalPokerGameRooms);
+
+    // Pre-flop: guest1 calls the BB, host raises all-in, guest0 calls all-in,
+    // guest1 folds → showdown between host and guest0 only.
+    await guestTexasHoldemGameRooms[1].bet(round, 2);
+    await hostTexasHoldemGameRoom.bet(round, 99);
+    await guestTexasHoldemGameRooms[0].bet(round, 98);
+    await guestTexasHoldemGameRooms[1].fold(round);
+    await new Promise(r => setTimeout(r, 50));
+
+    // Board 6h 6s 2h 2s 9c makes guest1 (folded, 6c 7d) the best hand with
+    // sixes full of deuces; host (2c 3d) has deuces full of sixes; guest0 has
+    // only the board's two pairs.
+    const board: Array<{suit: string, rank: string}> = [
+      {suit: 'Heart', rank: '6'},
+      {suit: 'Spade', rank: '6'},
+      {suit: 'Heart', rank: '2'},
+      {suit: 'Spade', rank: '2'},
+      {suit: 'Club', rank: '9'},
+    ];
+    board.forEach((card, offset) => {
+      for (const mpgr of allRooms) {
+        mpgr.listener.emit('card', round, offset, card as any);
+      }
+    });
+    await new Promise(r => setTimeout(r, 50));
+
+    const winnerEvents = winnerSubscriber.pop();
+    expect(winnerEvents.length).toBe(1);
+    const winningResult = winnerEvents[0][0];
+    expect(winningResult.how).toBe('Showdown');
+    if (winningResult.how === 'Showdown') {
+      // the folded guest1 must not appear anywhere in the showdown ranking
+      for (const rank of winningResult.showdown) {
+        expect(rank.players).not.toContain('guest1');
+      }
+      expect(winningResult.showdown[0].players).toEqual(['host']);
+    }
+
+    // host wins the whole pot: 100 (host) + 100 (guest0) + 2 (guest1's call)
+    const fundEvents = fundSubscriber.pop();
+    const lastHostFund = fundEvents.filter(([, , whose]) => whose === 'host').pop();
+    expect(lastHostFund![0]).toBe(202);
+    // the folded player keeps 98 and receives no award
+    const lastGuest1Fund = fundEvents.filter(([, , whose]) => whose === 'guest1').pop();
+    expect(lastGuest1Fund![0]).toBe(98);
+  }, {guests: 2});
 
   testHostAndGuest('raise resets called players and gives opponent another turn', async (
     {

--- a/src/lib/texas-holdem/TexasHoldemGameRoom.ts
+++ b/src/lib/texas-holdem/TexasHoldemGameRoom.ts
@@ -318,6 +318,11 @@ export class TexasHoldemGameRoom {
         }> = [];
         const board = cards.slice(0, 5);
         for (let playerOffset = 0; playerOffset < players.length; ++ playerOffset) {
+          const player = players[playerOffset];
+          if (roundData.foldPlayers.has(player)) {
+            // folded players are not eligible to win at showdown
+            continue;
+          }
           const holeOffsets = [
             playerOffset * 2 + 5,
             playerOffset * 2 + 6,
@@ -329,7 +334,6 @@ export class TexasHoldemGameRoom {
           const holeAndBoard = [...hole, ...board];
           const strength = evaluateStandardCards(holeAndBoard);
           const handValue = handRank(strength);
-          const player = players[playerOffset];
           strengthOfPlayers.push({
             player,
             handValue,
@@ -351,11 +355,13 @@ export class TexasHoldemGameRoom {
           }
         }
 
-        this.emitter.emit('winner', {
+        const winningResult: ShowdownResult = {
           how: 'Showdown',
           round,
           showdown: result,
-        });
+        };
+        roundData.result = winningResult;
+        this.emitter.emit('winner', winningResult);
 
         const awards = this.calculateAwards(roundData, result);
         for (let [winner, award] of Array.from(awards.entries())) {


### PR DESCRIPTION
Investigation of short GA sessions found the game can die silently on any
transient WebRTC drop (dandelion-mesh never re-dials peers and PeerJS never
reconnects to its signaling server) and that folded players were wrongly
included in showdown ranking, letting a folded hand win the pot.

Changes:
- src/lib/analytics.ts: safe gtag wrapper (no-op without gtag, GA4 param
  truncation) with trackEvent/trackError.
- src/lib/instrumentation.ts: replay-aware game telemetry — round_start,
  round_end (+duration), player_action (own actions only), game_room_status,
  and a game_stalled watchdog that fires when a pending turn sees no action
  for 2 minutes.
- src/lib/connectionResilience.ts: watches mesh membership, re-dials lost
  peers every 5s for up to 2 minutes, and reports peer_connected, peer_lost,
  peer_reconnected and peer_reconnect_failed.
- src/lib/setup.ts: ice_config_loaded (TURN vs STUN-only fallback outcome),
  peer_open, connection_error, raft_leader_changed, bootstrap_connect_result
  (did a joiner reach the host within 30s), js_error global handlers,
  signaling_lost/signaling_restored with automatic peer.reconnect(); the
  mesh is shielded from repeated 'open' events so a signaling reconnect
  cannot spawn a second Raft node.
- src/lib/GameRoom.ts: msg_send_failed when send retries are exhausted and
  app_error from event-handler exceptions.
- TexasHoldemGameRoom: folded players are excluded from showdown ranking and
  awards; the showdown result now marks the round as ended so late bets are
  rejected (regression-tested).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QFFdA8oyFexqgR3gA48L7U