### PR TITLE
build(deps): bump dandelion-mesh to ^1.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@types/node": "^16.18.97",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
-        "dandelion-mesh": "^1.0.0",
+        "dandelion-mesh": "^1.0.1",
         "eventemitter3": "^5.0.1",
         "mental-poker-toolkit": "^1.0.1",
         "peerjs": "^1.5.4",
@@ -6671,9 +6671,9 @@
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA=="
     },
     "node_modules/dandelion-mesh": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/dandelion-mesh/-/dandelion-mesh-1.0.0.tgz",
-      "integrity": "sha512-3HiFVHWU56eTGYpaJ9oO7BO532dnLn+2qi/0fuiTUP7mMgQ5PaDCfADWfxFgNj1r5WmIyjhGx8EJqyrIv5YWiA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dandelion-mesh/-/dandelion-mesh-1.0.1.tgz",
+      "integrity": "sha512-j9lP7dGIA6NGm8/Zg6j82pUo+oueuwJgt5Z+bcCi2+sKZeGpu1E7ki/zX6Zj5S0JTh2rltHHGc76Ry1BnSqaEg==",
       "license": "MIT",
       "dependencies": {
         "peerjs": "^1.5.5"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@types/node": "^16.18.97",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
-    "dandelion-mesh": "^1.0.0",
+    "dandelion-mesh": "^1.0.1",
     "eventemitter3": "^5.0.1",
     "mental-poker-toolkit": "^1.0.1",
     "peerjs": "^1.5.4",


### PR DESCRIPTION
Bumps `dandelion-mesh` from `^1.0.0` to `^1.0.1` ([release notes](https://github.com/predatorray/dandelion-mesh/releases/tag/v1.0.1)).

The patch release fixes mesh split-brain bugs and adds automatic retry/reconnect for failed WebRTC connections (predatorray/dandelion-mesh#1). For this app that means:

- Simultaneous host↔guest connections can no longer race into a state where both sides disconnect and each elects its own game-log leader.
- Dropped WebRTC connections (transient network issues, page refreshes) are automatically re-dialed with exponential backoff instead of partitioning the table permanently.
- A guest whose connection to the host is slow to establish no longer forms its own single-node Raft cluster, which previously could permanently diverge the game log on merge (lost public-key announcements, hung private messages).

No code changes required — the API is fully backward compatible.

Verified locally against the published `dandelion-mesh@1.0.1` tarball:
- `tsc --noEmit`: ✅
- Jest unit tests: **194/194 passed**
- (The full Playwright e2e suite was previously run against this identical library code: 18 passed, 1 pre-existing skip.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LwcJ5vHnmw1cxACvQW3Pot

---
_Generated by [Claude Code](https://claude.ai/code/session_01LwcJ5vHnmw1cxACvQW3Pot)_